### PR TITLE
fix: move example-only deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react": "^18.3.1 || ^19.0.0"
   },
   "devDependencies": {
+    "@clerk/clerk-react": "^5.57.0",
     "@convex-dev/eslint-plugin": "^1.0.0",
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/eslintrc": "^3.3.1",
@@ -69,6 +70,7 @@
     "@types/node": "^20.19.25",
     "@types/react": "^18.3.27",
     "@types/react-dom": "^18.3.7",
+    "@vercel/analytics": "^1.5.0",
     "@vitejs/plugin-react": "^5.1.1",
     "chokidar-cli": "3.0.0",
     "convex": "1.29.3",
@@ -93,8 +95,6 @@
   "types": "./dist/client/index.d.ts",
   "module": "./dist/client/index.js",
   "dependencies": {
-    "@clerk/clerk-react": "^5.57.0",
-    "@vercel/analytics": "^1.5.0",
     "stripe": "^20.0.0"
   }
 }


### PR DESCRIPTION
@clerk/clerk-react and @vercel/analytics are only used in the example app, not in the actual component source code. Moving them to devDependencies reduces unnecessary bloat for users installing @convex-dev/stripe.