### PR TITLE
fix: subscription sync on plan change and cancellation

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -93,12 +93,15 @@ export class StripeSubscriptions {
     }
 
     // Update local database immediately (don't wait for webhook)
+    const item = subscription.items.data[0];
     await ctx.runMutation(this.component.private.handleSubscriptionUpdated, {
       stripeSubscriptionId: subscription.id,
       status: subscription.status,
-      currentPeriodEnd: subscription.items.data[0]?.current_period_end || 0,
+      currentPeriodEnd: item?.current_period_end || 0,
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
-      quantity: subscription.items.data[0]?.quantity ?? 1,
+      cancelAt: subscription.cancel_at || undefined,
+      quantity: item?.quantity ?? 1,
+      priceId: item?.price?.id || undefined,
       metadata: subscription.metadata || {},
     });
 
@@ -126,12 +129,15 @@ export class StripeSubscriptions {
     );
 
     // Update local database immediately
+    const item = subscription.items.data[0];
     await ctx.runMutation(this.component.private.handleSubscriptionUpdated, {
       stripeSubscriptionId: subscription.id,
       status: subscription.status,
-      currentPeriodEnd: subscription.items.data[0]?.current_period_end || 0,
+      currentPeriodEnd: item?.current_period_end || 0,
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
-      quantity: subscription.items.data[0]?.quantity ?? 1,
+      cancelAt: subscription.cancel_at || undefined,
+      quantity: item?.quantity ?? 1,
+      priceId: item?.price?.id || undefined,
       metadata: subscription.metadata || {},
     });
 
@@ -459,27 +465,34 @@ async function processEvent(
 
     case "customer.subscription.created": {
       const subscription = event.data.object as StripeSDK.Subscription;
+      const item = subscription.items.data[0];
+      
       await ctx.runMutation(component.private.handleSubscriptionCreated, {
         stripeSubscriptionId: subscription.id,
         stripeCustomerId: subscription.customer as string,
         status: subscription.status,
-        currentPeriodEnd: subscription.items.data[0]?.current_period_end || 0,
+        currentPeriodEnd: item?.current_period_end || 0,
         cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+        cancelAt: subscription.cancel_at || undefined,
         quantity: subscription.items.data[0]?.quantity ?? 1,
-        priceId: subscription.items.data[0]?.price.id || "",
+        priceId: item?.price?.id || "",
         metadata: subscription.metadata || {},
       });
       break;
     }
 
     case "customer.subscription.updated": {
-      const subscription = event.data.object as any;
+      const subscription = event.data.object as StripeSDK.Subscription;
+      const item = subscription.items.data[0];
+
       await ctx.runMutation(component.private.handleSubscriptionUpdated, {
         stripeSubscriptionId: subscription.id,
         status: subscription.status,
-        currentPeriodEnd: subscription.items.data[0]?.current_period_end || 0,
+        currentPeriodEnd: item?.current_period_end || 0,
         cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+        cancelAt: subscription.cancel_at || undefined,
         quantity: subscription.items.data[0]?.quantity ?? 1,
+        priceId: item?.price?.id || undefined,
         metadata: subscription.metadata || {},
       });
       break;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -108,6 +108,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;
@@ -131,9 +132,11 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;
+          priceId?: string;
           quantity?: number;
           status: string;
           stripeSubscriptionId: string;
@@ -203,6 +206,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { stripeSubscriptionId: string },
         {
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;
@@ -221,6 +225,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { orgId: string },
         {
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;
@@ -341,6 +346,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { stripeCustomerId: string },
         Array<{
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;
@@ -359,6 +365,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { userId: string },
         Array<{
+          cancelAt?: number;
           cancelAtPeriodEnd: boolean;
           currentPeriodEnd: number;
           metadata?: any;

--- a/src/component/_generated/dataModel.ts
+++ b/src/component/_generated/dataModel.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -16,6 +16,7 @@ export default defineSchema({
     status: v.string(),
     currentPeriodEnd: v.number(),
     cancelAtPeriodEnd: v.boolean(),
+    cancelAt: v.optional(v.number()),
     quantity: v.optional(v.number()),
     priceId: v.string(),
     metadata: v.optional(v.any()),


### PR DESCRIPTION
Fixes subscription state desync in two cases:

- Plan/price changes: persist updated priceId from customer.subscription.updated
- Cancellation: handle Stripe flows where cancel_at is set (often ~= current_period_end) while cancel_at_period_end remains false
