### PR TITLE
Add checkout promotion code and UI params

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -160,6 +160,8 @@ export class StripeSubscriptions {
       subscriptionMetadata?: Record<string, string>;
       /** Metadata to attach to the payment intent (only for mode: "payment") */
       paymentIntentMetadata?: Record<string, string>;
+      allow_promotion_codes?: boolean
+      ui_mode?: "custom" | "embedded" | "hosted"
     },
   ) {
     const stripe = new StripeSDK(this.apiKey);
@@ -175,6 +177,8 @@ export class StripeSubscriptions {
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       metadata: args.metadata || {},
+      allow_promotion_codes: args.allow_promotion_codes,
+      ui_mode: args.ui_mode
     };
 
     if (args.customerId) {


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR adds the `allow_promotion_codes` and `ui_mode` params to `StripeSubscriptions.createCheckoutSession()`.

This PR resolves #15.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
