### PR TITLE
docs: add changelog entry for 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- Fix subscription sync: `priceId` now updates on plan changes, and `cancelAtPeriodEnd` is correctly derived when Stripe sets `cancel_at`
+
 ## 0.1.2
 
 - Fix updateSubscriptionQuantity: we now pass in STRIPE_SECRET_KEY explicitly.


### PR DESCRIPTION
Document the subscription sync fix from PR #11:
- priceId now updates on plan changes
- cancelAtPeriodEnd correctly derived from cancel_at

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
