### PR TITLE
Improve webhook handler robustness: upserts, final state, customer.deleted

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -464,17 +464,25 @@ async function processEvent(
       break;
     }
 
+    case "customer.deleted": {
+      const customer = event.data.object as StripeSDK.Customer;
+      await ctx.runMutation(component.private.handleCustomerDeleted, {
+        stripeCustomerId: customer.id,
+      });
+      break;
+    }
+
     case "customer.subscription.created": {
       const subscription = event.data.object as StripeSDK.Subscription;
       const item = subscription.items.data[0];
-      
+
       await ctx.runMutation(component.private.handleSubscriptionCreated, {
         stripeSubscriptionId: subscription.id,
         stripeCustomerId: subscription.customer as string,
         status: subscription.status,
         currentPeriodEnd: item?.current_period_end || 0,
         cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
-        cancelAt: subscription.cancel_at || undefined,
+        cancelAt: subscription.cancel_at ?? undefined,
         quantity: subscription.items.data[0]?.quantity ?? 1,
         priceId: item?.price?.id || "",
         metadata: subscription.metadata || {},
@@ -488,10 +496,11 @@ async function processEvent(
 
       await ctx.runMutation(component.private.handleSubscriptionUpdated, {
         stripeSubscriptionId: subscription.id,
+        stripeCustomerId: subscription.customer as string,
         status: subscription.status,
         currentPeriodEnd: item?.current_period_end || 0,
         cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
-        cancelAt: subscription.cancel_at || undefined,
+        cancelAt: subscription.cancel_at ?? undefined,
         quantity: subscription.items.data[0]?.quantity ?? 1,
         priceId: item?.price?.id || undefined,
         metadata: subscription.metadata || {},
@@ -501,8 +510,11 @@ async function processEvent(
 
     case "customer.subscription.deleted": {
       const subscription = event.data.object as StripeSDK.Subscription;
+      const item = subscription.items.data[0];
       await ctx.runMutation(component.private.handleSubscriptionDeleted, {
         stripeSubscriptionId: subscription.id,
+        currentPeriodEnd: item?.current_period_end || undefined,
+        cancelAt: subscription.cancel_at ?? undefined,
       });
       break;
     }


### PR DESCRIPTION
## Summary

Five webhook handler fixes in one PR since they're all closely related:

- **`handleSubscriptionUpdated` now upserts** — if `subscription.updated` arrives before `subscription.created` (webhook ordering), the data was silently dropped. Now creates the record if missing, preventing lost subscriptions.
- **`handleInvoiceCreated` now updates existing invoices** — `invoice.finalized` called the same handler as `invoice.created`, but it was insert-only. Updated amounts, status, and subscription links from finalization were silently dropped. Now patches existing records.
- **`handleSubscriptionDeleted` stores final state** — previously only set `status: "canceled"` and discarded `currentPeriodEnd`, `cancelAt` from the event. Now stores the final timestamps.
- **Add `customer.deleted` event handling** — deletes the customer record when a customer is removed in Stripe (dashboard or API). Previously left stale records.
- **Fix `cancelAt || undefined` → `cancelAt ?? undefined`** — `||` coerces a valid `0` timestamp to `undefined`. Changed to `??` throughout for correctness.

## Test plan

- [ ] Verify `subscription.updated` arriving before `subscription.created` now creates the subscription record
- [ ] Verify `invoice.finalized` updates existing invoice records (amount, status)
- [ ] Verify `subscription.deleted` stores `currentPeriodEnd` and `cancelAt` in the record
- [ ] Verify `customer.deleted` removes the customer from the database
- [ ] Verify existing webhook flows still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)