### PR TITLE
Stabilize Stripe component recovery work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           npm i
           npm run build
       - name: Publish package for testing branch
-        run: npx pkg-pr-new publish || echo "Have you set up pkg-pr-new for this repo?"
+        run: npx pkg-pr-new publish || echo "pkg-pr-new failed"
       - name: Test
         run: |
           npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Upgrade Stripe Node SDK dependency to v22.
+- Add optional Stripe API version configuration.
+- Add Checkout session params passthrough.
+- Improve webhook robustness for subscription updates, invoice upserts, invoice
+  metadata linking, and customer deletion PII scrubbing.
+- Refresh vulnerable dev/example dependencies without major toolchain upgrades.
+
 ## 0.1.4
 
 - Fix subscription quantity updates outside component actions

--- a/README.md
+++ b/README.md
@@ -175,8 +175,15 @@ import { StripeSubscriptions } from "@convex-dev/stripe";
 
 const stripeClient = new StripeSubscriptions(components.stripe, {
   STRIPE_SECRET_KEY: "sk_...", // Optional, defaults to process.env.STRIPE_SECRET_KEY
+  apiVersion: "2026-04-22.dahlia", // Optional Stripe API version pin
 });
 ```
+
+This package uses Stripe's Node SDK v22, which requires Node.js 18 or newer.
+You can pass `apiVersion` if your app needs to pin a specific Stripe API
+version instead of using the version bundled with the installed SDK. Stripe's
+TypeScript types model the latest API version, so older pinned versions can have
+runtime shapes that differ from the SDK types.
 
 #### Methods
 
@@ -203,8 +210,21 @@ await stripeClient.createCheckoutSession(ctx, {
   metadata: {},                     // Optional, session metadata
   subscriptionMetadata: {},         // Optional, attached to subscription
   paymentIntentMetadata: {},        // Optional, attached to payment intent
+  params: {
+    allow_promotion_codes: true,
+    ui_mode: "embedded_page",
+    return_url: "https://...",
+    automatic_tax: { enabled: true },
+  },                                // Optional Stripe Checkout params
 });
 ```
+
+`params` is passed through to Stripe Checkout and can be used for options like
+promotion codes, discounts, automatic tax, embedded checkout, custom fields, or
+custom line items. The component keeps `mode` from the top-level argument so
+webhook routing remains consistent. For non-hosted Checkout UI modes such as
+`embedded_page` or `elements`, the component omits `successUrl` and `cancelUrl`
+from the Stripe request; pass `return_url` through `params` instead.
 
 ### Component Queries
 

--- a/docs/dependency-cleanup.md
+++ b/docs/dependency-cleanup.md
@@ -1,0 +1,33 @@
+# Dependency Cleanup Notes
+
+Recorded after the recovery branch validated on Stripe SDK v22.
+
+## Landed in This Wave
+
+- Upgraded `stripe` to `^22.1.1`.
+- Updated security-sensitive dev/example dependencies without taking major toolchain
+  jumps:
+  - `@clerk/clerk-react` to `5.61.6`
+  - `vite` to `6.4.2`
+  - `pkg-pr-new` to `0.0.71`
+- Ran `npm audit fix` without `--force`; audit now reports 0 vulnerabilities.
+
+## Renovate PR Decisions
+
+| PR | Decision |
+| --- | --- |
+| `#46` Stripe v22 | Superseded by this branch. Close after this branch lands. |
+| `#37` lock maintenance | Close and let Renovate recreate from the new lockfile. |
+| `#40` routine updates | Rebase/recreate after this branch lands; current diff is too broad. |
+| `#41` Vercel Analytics v2 | Re-run separately after recovery; do not mix with Stripe/webhook fixes. |
+| `#42` React plugin v6 | Re-run separately with Vite compatibility checks. |
+| `#44` globals v17 | Low priority; re-run after ESLint stack is decided. |
+| `#45` Node 24 | Defer. CI should stay on Node 20 for this release because Stripe v22 only requires Node 18+. |
+| `#47` TypeScript 6 | Defer until Convex and Vitest typecheck behavior is known stable on TS 6. |
+| `#48` Vite 8 | Defer; large dev-server/build jump not needed for this release. |
+| `#49` Convex ESLint plugin v2 | Revisit separately. This branch enables the existing Convex plugin first. |
+
+## Current Guidance
+
+Merge or close dependency PRs one at a time after this recovery branch lands. Keep
+the Stripe v22 and webhook fixes isolated from broad frontend/toolchain updates.

--- a/docs/github-triage.md
+++ b/docs/github-triage.md
@@ -1,0 +1,43 @@
+# GitHub Issue and PR Triage
+
+This document captures the maintenance and feature triage for the next recovery
+wave of `@convex-dev/stripe`.
+
+## Issue Decisions
+
+| Issue | Decision | Notes |
+| --- | --- | --- |
+| `#50` Leaky `createCheckoutSession` abstraction | Fix now | Add a typed checkout params passthrough so common Stripe Checkout options do not require bypassing the component. |
+| `#35` Missing checkout params and discount expansion | Fix now | Covered by checkout params passthrough. Discount expansion should be documented as a caller-provided Stripe param. |
+| `#15` Allow `ui_mode` | Fix now | Covered by checkout params passthrough instead of adding one-off API fields. |
+| `#38` Missing `customer.deleted` handler | Fix now | Add a handler that removes PII while preserving the Stripe customer ID and relationship keys for audit/linking. |
+| `#24` Invoice webhook mutation retry conflict | Fix now | Make invoice writes idempotent/upsert-like so `invoice.created`, `invoice.finalized`, and later status events can arrive repeatedly or out of order. |
+| `#19` Invoice `userId`/`orgId` metadata | Fix now | Prefer invoice metadata, then fall back to linked subscription metadata. |
+| `#14` Stripe API version option | Fix now | Add an optional Stripe client config path so applications can pin API version intentionally. |
+| `#25` Dependency dashboard | Track | Keep as dependency tracking; resolve individual Renovate PRs after the recovery branch is green. |
+
+Closed issues are treated as historical context unless a regression is found.
+
+## PR Decisions
+
+| PR | Decision | Notes |
+| --- | --- | --- |
+| `#51` use convex linter | Reimplement/merge equivalent | Keep the lint rules and warning fixes, but avoid unnecessary generated churn. |
+| `#46` Stripe v22 | Reimplement | Small dependency bump. Existing CI failure is from stale generated/API shape, so land after codegen and compatibility fixes. |
+| `#27` Checkout params passthrough | Reimplement | Best shape for `#50`, `#35`, and `#15`, with tests and docs added. |
+| `#29` Webhook robustness | Rework | Good direction, but conflicts and needs soft PII deletion plus tests. |
+| `#20` Invoice metadata | Fold into webhook work | Implement alongside invoice upsert behavior. |
+| `#36` additionalParams escape hatch | Superseded | Close after the `#27`-style API lands. |
+| `#16` promotion code and UI params | Superseded | Close after the general checkout params API lands. |
+| `#6` products and prices | Design next | Valuable but too large/conflicting for the maintenance release; split into a dedicated feature wave. |
+| Renovate `#40`, `#41`, `#42`, `#44`, `#45`, `#47`, `#48`, `#49` | Defer/rebase | Do not merge failing or artifact-conflicted dependency PRs as-is. Revisit after Stripe v22 and lint cleanup. |
+| `#37` lock maintenance | Close/recreate | Conflicting and stale; prefer a fresh lockfile update after recovery work. |
+
+## Release Waves
+
+1. **Recovery release**: branch hygiene, lint/codegen, checkout params, webhook
+   robustness, Stripe v22, docs, and tests.
+2. **Dependency cleanup**: rerun Renovate on the green baseline and merge only
+   compatible updates.
+3. **Feature expansion**: products/prices support after schema and public API
+   design review.

--- a/docs/products-prices-design.md
+++ b/docs/products-prices-design.md
@@ -1,0 +1,117 @@
+# Products and Prices Feature Design
+
+Products and prices should ship as a separate feature wave after the recovery
+release. The goal is to mirror Stripe catalog data into Convex without coupling
+catalog sync to subscription/payment correctness.
+
+## Goals
+
+- Mirror Stripe `product.*` and `price.*` webhook events into component tables.
+- Expose public queries for active products and prices.
+- Support manual sync actions for backfills and local development.
+- Preserve Stripe metadata and key billing fields without over-modeling every
+  Stripe catalog option.
+
+## Non-Goals
+
+- Do not replace Stripe as the catalog source of truth.
+- Do not implement product creation or price creation from Convex in the first
+  wave.
+- Do not merge this into the Stripe v22 maintenance release.
+
+## Proposed Schema
+
+```typescript
+products: defineTable({
+  stripeProductId: v.string(),
+  active: v.boolean(),
+  name: v.string(),
+  description: v.optional(v.string()),
+  images: v.optional(v.array(v.string())),
+  metadata: v.optional(v.any()),
+  defaultPriceId: v.optional(v.string()),
+  livemode: v.optional(v.boolean()),
+  updated: v.optional(v.number()),
+})
+  .index("by_stripe_product_id", ["stripeProductId"])
+  .index("by_active", ["active"]);
+
+prices: defineTable({
+  stripePriceId: v.string(),
+  stripeProductId: v.string(),
+  active: v.boolean(),
+  currency: v.string(),
+  type: v.string(),
+  unitAmount: v.optional(v.number()),
+  unitAmountDecimal: v.optional(v.string()),
+  recurring: v.optional(v.any()),
+  lookupKey: v.optional(v.string()),
+  metadata: v.optional(v.any()),
+  livemode: v.optional(v.boolean()),
+})
+  .index("by_stripe_price_id", ["stripePriceId"])
+  .index("by_stripe_product_id", ["stripeProductId"])
+  .index("by_active", ["active"])
+  .index("by_lookup_key", ["lookupKey"]);
+```
+
+Use `unitAmountDecimal` as a string because Stripe v21+ models decimal values
+more strictly, and consumers should not lose precision by forcing decimals into
+JavaScript numbers.
+
+## Component API
+
+Public queries:
+
+- `getProduct({ stripeProductId })`
+- `listActiveProducts()`
+- `listPrices({ stripeProductId })`
+- `getPrice({ stripePriceId })`
+- `getPriceByLookupKey({ lookupKey })`
+
+Private mutations:
+
+- `handleProductUpsert`
+- `handleProductDeleted`
+- `handlePriceUpsert`
+- `handlePriceDeleted`
+
+Client actions:
+
+- `syncProduct(ctx, { stripeProductId })`
+- `syncPrice(ctx, { stripePriceId })`
+- `syncCatalog(ctx, { activeOnly?: boolean, limit?: number })`
+
+## Webhook Events
+
+Register default handling for:
+
+- `product.created`
+- `product.updated`
+- `product.deleted`
+- `price.created`
+- `price.updated`
+- `price.deleted`
+
+Deletions should not hard-delete rows by default. Mark `active: false` and keep
+Stripe IDs for historical subscriptions, invoices, and payments.
+
+## Testing Plan
+
+- Upsert product from create/update events.
+- Upsert price from create/update events, including recurring metadata.
+- Mark product and price inactive on deleted events.
+- Query active products and prices by product ID.
+- Query prices by lookup key.
+- Backfill sync action writes the same shape as webhook handlers.
+- Verify decimal amounts preserve string precision.
+
+## Rollout
+
+1. Add schema and private mutations.
+2. Add public queries.
+3. Add webhook dispatch.
+4. Add sync actions.
+5. Add README examples for catalog-driven checkout.
+6. Re-evaluate PR `#6` against the final API and close it as superseded or
+   extract any remaining tests/examples.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import convexPlugin from "@convex-dev/eslint-plugin";
 
 export default [
   {
@@ -38,7 +39,11 @@ export default [
     languageOptions: {
       globals: globals.worker,
     },
+    plugins: {
+      "@convex-dev": convexPlugin,
+    },
     rules: {
+      ...convexPlugin.configs.recommended[0].rules,
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-explicit-any": "off",
       "no-unused-vars": "off",

--- a/example/convex/stripe.ts
+++ b/example/convex/stripe.ts
@@ -452,7 +452,7 @@ export const getCustomerPortalUrl = action({
     }),
     v.null(),
   ),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Not authenticated");
 
@@ -577,7 +577,7 @@ export const getUserSubscriptions = query({
       orgId: v.optional(v.string()),
     }),
   ),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return [];
 
@@ -606,7 +606,7 @@ export const getUserPayments = query({
       orgId: v.optional(v.string()),
     }),
   ),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return [];
 
@@ -629,7 +629,7 @@ export const getFailedPaymentSubscriptions = query({
       currentPeriodEnd: v.number(),
     }),
   ),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return [];
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -891,12 +891,8 @@ function ProfilePage({
 // TEAM BILLING PAGE (#4 - Organization-Based Lookups)
 // ============================================================================
 
-function TeamBillingPage({
-  setCurrentPage,
-}: {
-  setCurrentPage: (page: Page) => void;
-}) {
-  const { isSignedIn, user } = useUser();
+function TeamBillingPage() {
+  const { isSignedIn } = useUser();
   const [orgId, setOrgId] = useState("demo-org-123");
 
   // Using the org-based queries
@@ -1308,9 +1304,7 @@ function App() {
       {currentPage === "profile" && (
         <ProfilePage setCurrentPage={setCurrentPage} />
       )}
-      {currentPage === "team" && (
-        <TeamBillingPage setCurrentPage={setCurrentPage} />
-      )}
+      {currentPage === "team" && <TeamBillingPage />}
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "stripe": "^20.0.0"
+        "stripe": "^22.1.1"
       },
       "devDependencies": {
-        "@clerk/clerk-react": "5.57.0",
+        "@clerk/clerk-react": "5.61.6",
         "@convex-dev/eslint-plugin": "1.0.0",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.1",
@@ -30,58 +30,19 @@
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.24",
         "globals": "16.5.0",
-        "pkg-pr-new": "0.0.60",
+        "pkg-pr-new": "0.0.71",
         "prettier": "3.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "typescript": "5.9.3",
         "typescript-eslint": "8.55.0",
-        "vite": "6.4.1",
+        "vite": "6.4.2",
         "vitest": "3.2.4"
       },
       "peerDependencies": {
         "convex": "^1.29.3",
         "react": "^18.3.1 || ^19.0.0"
       }
-    },
-    "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
-      }
-    },
-    "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@actions/io": "^1.0.1"
-      }
-    },
-    "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
-    "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -366,27 +327,27 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.57.0.tgz",
-      "integrity": "sha512-GCBFF03HjEWvx58myjauJ7NrwTqhxHdetjWWxVM3YJGPOsAVXg4WuquL/hyn8KDuduCYSkRin4Hg6+QVP1NXAg==",
+      "version": "5.61.6",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
+      "integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.36.0",
+        "@clerk/shared": "^3.47.5",
         "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.36.0.tgz",
-      "integrity": "sha512-Yp4tL/x/iVft40DnxBjT/g/kQilZ+i9mYrqC1Lk6fUnfZV8t7E54GX19JtJSSONzjHsH6sCv3BmJaF1f7Eomkw==",
+      "version": "3.47.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -402,8 +363,8 @@
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -574,9 +535,9 @@
       }
     },
     "node_modules/@convex-dev/eslint-plugin/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -584,13 +545,13 @@
       }
     },
     "node_modules/@convex-dev/eslint-plugin/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1249,16 +1210,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1361,22 +1312,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ez-spawn": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
-      "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "cross-spawn": "^7.0.3",
-        "string-argv": "^0.3.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1415,288 +1350,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octokit/action": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.1.0.tgz",
-      "integrity": "sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-action": "^4.0.0",
-        "@octokit/core": "^5.0.0",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
-        "@octokit/types": "^12.0.0",
-        "undici": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/action/node_modules/undici": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@octokit/auth-action": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-4.1.0.tgz",
-      "integrity": "sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/types": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/auth-action/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^8.4.1",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^9.0.6",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.47.tgz",
@@ -1705,9 +1358,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -1719,9 +1372,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1733,9 +1386,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -1747,9 +1400,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -1761,9 +1414,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -1775,9 +1428,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -1789,9 +1442,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -1803,9 +1456,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -1817,9 +1470,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -1831,9 +1484,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -1845,9 +1498,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -1859,9 +1526,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -1873,9 +1554,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -1887,9 +1568,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1901,9 +1582,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -1915,9 +1596,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -1929,9 +1610,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -1942,10 +1623,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -1957,9 +1652,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -1971,9 +1666,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -1985,9 +1680,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -1999,9 +1694,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -2316,9 +2011,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2326,13 +2021,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2595,9 +2290,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2849,13 +2544,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2870,9 +2558,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2986,13 +2674,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3159,13 +2840,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3796,16 +3470,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -3858,13 +3522,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -4483,19 +4140,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4528,9 +4172,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5324,19 +4968,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isbinaryfile": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
-      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5591,9 +5222,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5601,19 +5232,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
       }
     },
     "node_modules/ms": {
@@ -5774,16 +5392,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5927,9 +5535,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5940,35 +5548,13 @@
       }
     },
     "node_modules/pkg-pr-new": {
-      "version": "0.0.60",
-      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.60.tgz",
-      "integrity": "sha512-eblxPNSgv0AO18OrfpHq+YrNHfEqeePWWvlKkPvcHByddGsGDOK25z41C1RDjZ+K8zUHDk5IGN+6n0WZa4T2Pg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.71.tgz",
+      "integrity": "sha512-Ln7I7NaOXN6CjBLVrNqsWOo6mIaNW4chH4eCR2t4tnQSmYtyQiWCqlMG6bL2JYCT1MOiKEiDObnnzePGh0TNFQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@jsdevtools/ez-spawn": "^3.0.4",
-        "@octokit/action": "^6.1.0",
-        "ignore": "^5.3.1",
-        "isbinaryfile": "^5.0.2",
-        "pkg-types": "^1.1.1",
-        "query-registry": "^3.0.1",
-        "tinyglobby": "^0.2.9"
-      },
       "bin": {
         "pkg-pr-new": "bin/cli.js"
-      }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5982,9 +5568,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -6058,42 +5644,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/query-registry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/query-registry/-/query-registry-3.0.1.tgz",
-      "integrity": "sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "query-string": "^9.0.0",
-        "quick-lru": "^7.0.0",
-        "url-join": "^5.0.0",
-        "validate-npm-package-name": "^5.0.1",
-        "zod": "^3.23.8",
-        "zod-package-json": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
-      "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6114,19 +5664,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
-      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6286,9 +5823,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6302,28 +5839,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -6598,19 +6138,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6637,16 +6164,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -6809,15 +6326,15 @@
       "license": "MIT"
     },
     "node_modules/stripe": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.3.1.tgz",
-      "integrity": "sha512-k990yOT5G5rhX3XluRPw5Y8RLdJDW4dzQ29wWT66piHrbnM2KyamJ1dKgPsw4HzGHRWjDiSSdcI2WdxQUPV3aQ==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@types/node": ">=16"
+        "@types/node": ">=18"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -6915,9 +6432,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6990,16 +6507,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7011,16 +6518,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -7139,13 +6636,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -7165,32 +6655,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",
@@ -7233,16 +6703,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -7253,20 +6713,10 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/validate-npm-package-name": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7380,9 +6830,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7466,9 +6916,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7662,13 +7112,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -7812,29 +7255,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-package-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-package-json/-/zod-package-json-1.2.0.tgz",
-      "integrity": "sha512-tamtgPM3MkP+obfO2dLr/G+nYoYkpJKmuHdYEy6IXRKfLybruoJ5NUj0lM0LxwOpC9PpoGLbll1ecoeyj43Wsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.25.64"
-      },
-      "engines": {
-        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react": "^18.3.1 || ^19.0.0"
   },
   "devDependencies": {
-    "@clerk/clerk-react": "5.57.0",
+    "@clerk/clerk-react": "5.61.6",
     "@convex-dev/eslint-plugin": "1.0.0",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.1",
@@ -78,18 +78,18 @@
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.24",
     "globals": "16.5.0",
-    "pkg-pr-new": "0.0.60",
+    "pkg-pr-new": "0.0.71",
     "prettier": "3.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "typescript": "5.9.3",
     "typescript-eslint": "8.55.0",
-    "vite": "6.4.1",
+    "vite": "6.4.2",
     "vitest": "3.2.4"
   },
   "types": "./dist/client/index.d.ts",
   "module": "./dist/client/index.js",
   "dependencies": {
-    "stripe": "^20.0.0"
+    "stripe": "^22.1.1"
   }
 }

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -6,6 +6,8 @@ import { components } from "./setup.test.js";
 
 const stripeMocks = vi.hoisted(() => ({
   retrieveSubscription: vi.fn(),
+  updateSubscription: vi.fn(),
+  cancelSubscription: vi.fn(),
   updateSubscriptionItem: vi.fn(),
   createCheckoutSession: vi.fn(),
 }));
@@ -14,6 +16,8 @@ vi.mock("stripe", () => ({
   default: vi.fn().mockImplementation(() => ({
     subscriptions: {
       retrieve: stripeMocks.retrieveSubscription,
+      update: stripeMocks.updateSubscription,
+      cancel: stripeMocks.cancelSubscription,
     },
     subscriptionItems: {
       update: stripeMocks.updateSubscriptionItem,
@@ -123,6 +127,93 @@ describe("StripeSubscriptions client", () => {
       },
     );
     expect(ctx.runAction).not.toHaveBeenCalled();
+  });
+
+  test("cancelSubscription includes customer ID when syncing subscription", async () => {
+    stripeMocks.updateSubscription.mockResolvedValue({
+      id: "sub_cancel",
+      customer: "cus_cancel",
+      status: "active",
+      cancel_at_period_end: true,
+      cancel_at: 1_800_000_000,
+      metadata: { userId: "user_cancel" },
+      items: {
+        data: [
+          {
+            current_period_end: 1_800_000_000,
+            quantity: 3,
+            price: { id: "price_cancel" },
+          },
+        ],
+      },
+    });
+
+    const ctx = {
+      runAction: vi.fn(),
+      runMutation: vi.fn().mockResolvedValue(null),
+      runQuery: vi.fn(),
+    };
+    const client = new StripeSubscriptions(components.stripe, {
+      STRIPE_SECRET_KEY: "sk_test_123",
+    });
+
+    await client.cancelSubscription(ctx, {
+      stripeSubscriptionId: "sub_cancel",
+      cancelAtPeriodEnd: true,
+    });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      components.stripe.private.handleSubscriptionUpdated,
+      expect.any(Object),
+    );
+    expect(ctx.runMutation.mock.calls[0][1]).toMatchObject({
+      stripeSubscriptionId: "sub_cancel",
+      stripeCustomerId: "cus_cancel",
+      priceId: "price_cancel",
+    });
+  });
+
+  test("reactivateSubscription includes customer ID when syncing subscription", async () => {
+    stripeMocks.updateSubscription.mockResolvedValue({
+      id: "sub_reactivate",
+      customer: "cus_reactivate",
+      status: "active",
+      cancel_at_period_end: false,
+      cancel_at: null,
+      metadata: { userId: "user_reactivate" },
+      items: {
+        data: [
+          {
+            current_period_end: 1_800_000_000,
+            quantity: 2,
+            price: { id: "price_reactivate" },
+          },
+        ],
+      },
+    });
+
+    const ctx = {
+      runAction: vi.fn(),
+      runMutation: vi.fn().mockResolvedValue(null),
+      runQuery: vi.fn(),
+    };
+    const client = new StripeSubscriptions(components.stripe, {
+      STRIPE_SECRET_KEY: "sk_test_123",
+    });
+
+    await client.reactivateSubscription(ctx, {
+      stripeSubscriptionId: "sub_reactivate",
+    });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      components.stripe.private.handleSubscriptionUpdated,
+      expect.any(Object),
+    );
+    expect(ctx.runMutation.mock.calls[0][1]).toMatchObject({
+      stripeSubscriptionId: "sub_reactivate",
+      stripeCustomerId: "cus_reactivate",
+      priceId: "price_reactivate",
+    });
   });
 
   test("passes additional checkout session params without allowing mode override", async () => {

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test, vi } from "vitest";
+import StripeSDK from "stripe";
+import * as clientModule from "./index.js";
 import { StripeSubscriptions, registerRoutes } from "./index.js";
 import { components } from "./setup.test.js";
 
 const stripeMocks = vi.hoisted(() => ({
   retrieveSubscription: vi.fn(),
   updateSubscriptionItem: vi.fn(),
+  createCheckoutSession: vi.fn(),
 }));
 
 vi.mock("stripe", () => ({
@@ -14,6 +17,11 @@ vi.mock("stripe", () => ({
     },
     subscriptionItems: {
       update: stripeMocks.updateSubscriptionItem,
+    },
+    checkout: {
+      sessions: {
+        create: stripeMocks.createCheckoutSession,
+      },
     },
   })),
 }));
@@ -32,6 +40,37 @@ describe("StripeSubscriptions client", () => {
     expect(client).toBeDefined();
     // The apiKey getter should return the provided key
     expect(client.apiKey).toBe("sk_test_123");
+  });
+
+  test("should pass Stripe client configuration options to the SDK", async () => {
+    vi.mocked(StripeSDK).mockClear();
+    stripeMocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_config",
+      url: "https://checkout.stripe.com/c/pay/cs_config",
+    });
+
+    const client = new StripeSubscriptions(components.stripe, {
+      STRIPE_SECRET_KEY: "sk_test_123",
+      apiVersion: "2026-04-22.dahlia",
+    });
+
+    await client.createCheckoutSession(
+      {
+        runAction: vi.fn(),
+        runMutation: vi.fn(),
+        runQuery: vi.fn(),
+      },
+      {
+        priceId: "price_123",
+        mode: "payment",
+        successUrl: "https://example.com/success",
+        cancelUrl: "https://example.com/cancel",
+      },
+    );
+
+    expect(StripeSDK).toHaveBeenCalledWith("sk_test_123", {
+      apiVersion: "2026-04-22.dahlia",
+    });
   });
 
   test("should throw error when accessing apiKey without key set", async () => {
@@ -85,10 +124,152 @@ describe("StripeSubscriptions client", () => {
     );
     expect(ctx.runAction).not.toHaveBeenCalled();
   });
+
+  test("passes additional checkout session params without allowing mode override", async () => {
+    stripeMocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_test_123",
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+
+    const client = new StripeSubscriptions(components.stripe, {
+      STRIPE_SECRET_KEY: "sk_test_123",
+    });
+
+    const result = await client.createCheckoutSession(
+      {
+        runAction: vi.fn(),
+        runMutation: vi.fn(),
+        runQuery: vi.fn(),
+      },
+      {
+        priceId: "price_monthly",
+        customerId: "cus_123",
+        mode: "subscription",
+        successUrl: "https://example.com/success",
+        cancelUrl: "https://example.com/cancel",
+        quantity: 2,
+        metadata: { source: "test" },
+        subscriptionMetadata: { userId: "user_123" },
+        params: {
+          mode: "payment",
+          allow_promotion_codes: true,
+          line_items: [{ price: "price_override", quantity: 5 }],
+        },
+      },
+    );
+
+    expect(stripeMocks.createCheckoutSession).toHaveBeenCalledWith({
+      mode: "subscription",
+      line_items: [{ price: "price_override", quantity: 5 }],
+      success_url: "https://example.com/success",
+      cancel_url: "https://example.com/cancel",
+      metadata: { source: "test" },
+      customer: "cus_123",
+      subscription_data: { metadata: { userId: "user_123" } },
+      allow_promotion_codes: true,
+    });
+    expect(result).toEqual({
+      sessionId: "cs_test_123",
+      url: "https://checkout.stripe.com/c/pay/cs_test_123",
+    });
+  });
+
+  test("omits hosted redirect URLs for non-hosted checkout ui modes", async () => {
+    stripeMocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_embedded",
+      url: null,
+    });
+
+    const client = new StripeSubscriptions(components.stripe, {
+      STRIPE_SECRET_KEY: "sk_test_123",
+    });
+
+    await client.createCheckoutSession(
+      {
+        runAction: vi.fn(),
+        runMutation: vi.fn(),
+        runQuery: vi.fn(),
+      },
+      {
+        priceId: "price_monthly",
+        mode: "subscription",
+        successUrl: "https://example.com/success",
+        cancelUrl: "https://example.com/cancel",
+        params: {
+          ui_mode: "embedded_page",
+          return_url: "https://example.com/return",
+        },
+      },
+    );
+
+    expect(stripeMocks.createCheckoutSession).toHaveBeenCalledWith({
+      mode: "subscription",
+      line_items: [{ price: "price_monthly", quantity: 1 }],
+      metadata: {},
+      ui_mode: "embedded_page",
+      return_url: "https://example.com/return",
+    });
+  });
 });
 
 describe("registerRoutes", () => {
   test("registerRoutes function should be exported", () => {
     expect(typeof registerRoutes).toBe("function");
+  });
+});
+
+describe("processEvent", () => {
+  test("links v22 invoice events through parent subscription details", async () => {
+    const processEvent = (clientModule as any).processEvent;
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(null),
+      runQuery: vi.fn(),
+    };
+
+    await processEvent(
+      ctx,
+      components.stripe,
+      {
+        type: "invoice.created",
+        data: {
+          object: {
+            id: "in_v22",
+            customer: "cus_v22",
+            status: "open",
+            amount_due: 1234,
+            amount_paid: 0,
+            created: 1_700_000_001,
+            metadata: {},
+            parent: {
+              subscription_details: {
+                subscription: "sub_v22",
+                metadata: {
+                  userId: "user_v22",
+                  orgId: "org_v22",
+                },
+              },
+            },
+          },
+        },
+      },
+      {},
+    );
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      components.stripe.private.handleInvoiceCreated,
+      {
+        stripeInvoiceId: "in_v22",
+        stripeCustomerId: "cus_v22",
+        stripeSubscriptionId: "sub_v22",
+        status: "open",
+        amountDue: 1234,
+        amountPaid: 0,
+        created: 1_700_000_001,
+        metadata: {
+          userId: "user_v22",
+          orgId: "org_v22",
+        },
+      },
+    );
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -126,6 +126,7 @@ export class StripeSubscriptions {
     const item = subscription.items.data[0];
     await ctx.runMutation(this.component.private.handleSubscriptionUpdated, {
       stripeSubscriptionId: subscription.id,
+      stripeCustomerId: getStripeObjectId(subscription.customer),
       status: subscription.status,
       currentPeriodEnd: item?.current_period_end || 0,
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
@@ -162,6 +163,7 @@ export class StripeSubscriptions {
     const item = subscription.items.data[0];
     await ctx.runMutation(this.component.private.handleSubscriptionUpdated, {
       stripeSubscriptionId: subscription.id,
+      stripeCustomerId: getStripeObjectId(subscription.customer),
       status: subscription.status,
       currentPeriodEnd: item?.current_period_end || 0,
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
@@ -761,6 +763,10 @@ function getInvoiceSubscriptionId(invoice: StripeSDK.Invoice) {
     return legacySubscription.id;
   }
   return undefined;
+}
+
+function getStripeObjectId(object: string | { id: string }) {
+  return typeof object === "string" ? object : object.id;
 }
 
 function getInvoiceMetadata(invoice: StripeSDK.Invoice) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,8 +6,17 @@ import type {
   HttpRouter,
   RegisterRoutesConfig,
   StripeEventHandlers,
+  StripeApiVersion,
 } from "./types.js";
 import type { ComponentApi } from "../component/_generated/component.js";
+
+type StripeClientConfig = ConstructorParameters<typeof StripeSDK>[1];
+type StripeClientConfigWithApiVersion = Omit<
+  NonNullable<StripeClientConfig>,
+  "apiVersion"
+> & {
+  apiVersion?: StripeApiVersion;
+};
 
 /**
  * Time window (in seconds) to check for recent subscriptions when processing
@@ -28,19 +37,28 @@ export type { RegisterRoutesConfig, StripeEventHandlers };
  */
 export class StripeSubscriptions {
   private _apiKey: string;
+  private _stripeConfig: StripeClientConfigWithApiVersion | undefined;
   constructor(
     public component: StripeComponent,
     options?: {
       STRIPE_SECRET_KEY?: string;
+      apiVersion?: StripeApiVersion;
     },
   ) {
     this._apiKey = options?.STRIPE_SECRET_KEY ?? process.env.STRIPE_SECRET_KEY!;
+    this._stripeConfig = options?.apiVersion
+      ? { apiVersion: options.apiVersion }
+      : undefined;
   }
   get apiKey() {
     if (!this._apiKey) {
       throw new Error("STRIPE_SECRET_KEY environment variable is not set");
     }
     return this._apiKey;
+  }
+
+  private stripe() {
+    return new StripeSDK(this.apiKey, this._stripeConfig as StripeClientConfig);
   }
 
   /**
@@ -54,7 +72,7 @@ export class StripeSubscriptions {
       quantity: number;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
     const subscription = await stripe.subscriptions.retrieve(
       args.stripeSubscriptionId,
     );
@@ -86,7 +104,7 @@ export class StripeSubscriptions {
       cancelAtPeriodEnd?: boolean;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
     const cancelAtPeriodEnd = args.cancelAtPeriodEnd ?? true;
 
     let subscription: StripeSDK.Subscription;
@@ -130,7 +148,7 @@ export class StripeSubscriptions {
       stripeSubscriptionId: string;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
 
     // Reactivate by setting cancel_at_period_end to false
     const subscription = await stripe.subscriptions.update(
@@ -162,6 +180,11 @@ export class StripeSubscriptions {
 
   /**
    * Create a Stripe Checkout session for one-time payments or subscriptions.
+   *
+   * Use `params` to pass additional Stripe Checkout Session parameters directly
+   * to the Stripe API (e.g. allow_promotion_codes, billing_address_collection,
+   * shipping_address_collection, custom_fields, line_items, subscription_data, etc.).
+   * Values in `params` override constructed defaults except `mode`.
    */
   async createCheckoutSession(
     ctx: ActionCtx,
@@ -177,9 +200,11 @@ export class StripeSubscriptions {
       subscriptionMetadata?: Record<string, string>;
       /** Metadata to attach to the payment intent (only for mode: "payment") */
       paymentIntentMetadata?: Record<string, string>;
+      /** Additional Stripe Checkout Session parameters passed through to the API */
+      params?: Partial<StripeSDK.Checkout.SessionCreateParams>;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
 
     const sessionParams: StripeSDK.Checkout.SessionCreateParams = {
       mode: args.mode,
@@ -212,7 +237,14 @@ export class StripeSubscriptions {
       };
     }
 
-    const session = await stripe.checkout.sessions.create(sessionParams);
+    const { mode: _mode, ...paramsOverrides } = args.params || {};
+    const finalParams = { ...sessionParams, ...paramsOverrides };
+    if (finalParams.ui_mode && finalParams.ui_mode !== "hosted_page") {
+      delete finalParams.success_url;
+      delete finalParams.cancel_url;
+    }
+
+    const session = await stripe.checkout.sessions.create(finalParams);
 
     return {
       sessionId: session.id,
@@ -236,7 +268,7 @@ export class StripeSubscriptions {
       idempotencyKey?: string;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
 
     // Use idempotency key to prevent duplicate customers from race conditions
     const requestOptions = args.idempotencyKey
@@ -344,7 +376,7 @@ export class StripeSubscriptions {
       returnUrl: string;
     },
   ) {
-    const stripe = new StripeSDK(this.apiKey);
+    const stripe = this.stripe();
 
     const session = await stripe.billingPortal.sessions.create({
       customer: args.customerId,
@@ -425,7 +457,12 @@ export function registerRoutes(
         });
       }
 
-      const stripe = new StripeSDK(apiKey);
+      const stripe = new StripeSDK(
+        apiKey,
+        config?.apiVersion
+          ? ({ apiVersion: config.apiVersion } as StripeClientConfig)
+          : undefined,
+      );
 
       // Verify webhook signature
       let event: StripeSDK.Event;
@@ -477,7 +514,7 @@ export function registerRoutes(
  * Internal method to process Stripe webhook events with default handling.
  * This handles the database syncing for all supported event types.
  */
-async function processEvent(
+export async function processEvent(
   ctx: MutationCtx | ActionCtx,
   component: ComponentApi,
   event: StripeSDK.Event,
@@ -497,6 +534,14 @@ async function processEvent(
         email: customer.email || undefined,
         name: customer.name || undefined,
         metadata: customer.metadata,
+      });
+      break;
+    }
+
+    case "customer.deleted": {
+      const customer = event.data.object as StripeSDK.Customer;
+      await ctx.runMutation(component.private.handleCustomerDeleted, {
+        stripeCustomerId: customer.id,
       });
       break;
     }
@@ -525,6 +570,7 @@ async function processEvent(
 
       await ctx.runMutation(component.private.handleSubscriptionUpdated, {
         stripeSubscriptionId: subscription.id,
+        stripeCustomerId: subscription.customer as string,
         status: subscription.status,
         currentPeriodEnd: item?.current_period_end || 0,
         cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
@@ -604,13 +650,12 @@ async function processEvent(
       await ctx.runMutation(component.private.handleInvoiceCreated, {
         stripeInvoiceId: invoice.id,
         stripeCustomerId: invoice.customer as string,
-        stripeSubscriptionId: (invoice as any).subscription as
-          | string
-          | undefined,
+        stripeSubscriptionId: getInvoiceSubscriptionId(invoice),
         status: invoice.status || "open",
         amountDue: invoice.amount_due,
         amountPaid: invoice.amount_paid,
         created: invoice.created,
+        metadata: getInvoiceMetadata(invoice),
       });
       break;
     }
@@ -642,7 +687,7 @@ async function processEvent(
           const invoice = await stripe.invoices.retrieve(
             paymentIntent.invoice as string,
           );
-          if ((invoice as any).subscription) {
+          if (getInvoiceSubscriptionId(invoice)) {
             console.log(
               "⏭️ Skipping payment_intent.succeeded - subscription payment",
             );
@@ -693,6 +738,37 @@ async function processEvent(
     default:
       console.log(`ℹ️ Unhandled event type: ${event.type}`);
   }
+}
+
+function getInvoiceSubscriptionId(invoice: StripeSDK.Invoice) {
+  const parentSubscription = invoice.parent?.subscription_details?.subscription;
+  if (typeof parentSubscription === "string") {
+    return parentSubscription;
+  }
+  if (parentSubscription && "id" in parentSubscription) {
+    return parentSubscription.id;
+  }
+
+  const legacySubscription = (
+    invoice as StripeSDK.Invoice & {
+      subscription?: string | StripeSDK.Subscription | null;
+    }
+  ).subscription;
+  if (typeof legacySubscription === "string") {
+    return legacySubscription;
+  }
+  if (legacySubscription && "id" in legacySubscription) {
+    return legacySubscription.id;
+  }
+  return undefined;
+}
+
+function getInvoiceMetadata(invoice: StripeSDK.Invoice) {
+  const invoiceMetadata = invoice.metadata || {};
+  if (Object.keys(invoiceMetadata).length > 0) {
+    return invoiceMetadata;
+  }
+  return invoice.parent?.subscription_details?.metadata || {};
 }
 
 export default StripeSubscriptions;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,6 +6,13 @@ import type {
   GenericQueryCtx,
 } from "convex/server";
 import type Stripe from "stripe";
+import type StripeSDK from "stripe";
+
+type StripeClientConfig = ConstructorParameters<typeof StripeSDK>[1];
+export type StripeApiVersion =
+  | NonNullable<StripeClientConfig>["apiVersion"]
+  | (string & {})
+  | null;
 
 // Type utils follow
 
@@ -72,6 +79,12 @@ export type RegisterRoutesConfig = {
    * Defaults to process.env.STRIPE_SECRET_KEY
    */
   STRIPE_SECRET_KEY?: string;
+
+  /**
+   * Optional Stripe API version for the webhook Stripe client.
+   * Defaults to the API version bundled with the installed Stripe SDK.
+   */
+  apiVersion?: StripeApiVersion;
 };
 
 /**

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -48,6 +48,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         null,
         Name
       >;
+      handleCustomerDeleted: FunctionReference<
+        "mutation",
+        "internal",
+        { stripeCustomerId: string },
+        null,
+        Name
+      >;
       handleCustomerUpdated: FunctionReference<
         "mutation",
         "internal",
@@ -67,6 +74,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           amountDue: number;
           amountPaid: number;
           created: number;
+          metadata?: any;
           status: string;
           stripeCustomerId: string;
           stripeInvoiceId: string;
@@ -124,7 +132,12 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       handleSubscriptionDeleted: FunctionReference<
         "mutation",
         "internal",
-        { stripeSubscriptionId: string },
+        {
+          cancelAt?: number;
+          cancelAtPeriodEnd?: boolean;
+          currentPeriodEnd?: number;
+          stripeSubscriptionId: string;
+        },
         null,
         Name
       >;
@@ -139,9 +152,22 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           priceId?: string;
           quantity?: number;
           status: string;
+          stripeCustomerId?: string;
           stripeSubscriptionId: string;
         },
         null,
+        Name
+      >;
+      listSubscriptionsWithCreationTime: FunctionReference<
+        "query",
+        "internal",
+        { stripeCustomerId: string },
+        Array<{
+          _creationTime: number;
+          status: string;
+          stripeCustomerId: string;
+          stripeSubscriptionId: string;
+        }>,
         Name
       >;
       updatePaymentCustomer: FunctionReference<
@@ -172,6 +198,19 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         string,
         Name
       >;
+      getCheckoutSession: FunctionReference<
+        "query",
+        "internal",
+        { stripeCheckoutSessionId: string },
+        {
+          metadata?: any;
+          mode: string;
+          status: string;
+          stripeCheckoutSessionId: string;
+          stripeCustomerId?: string;
+        } | null,
+        Name
+      >;
       getCustomer: FunctionReference<
         "query",
         "internal",
@@ -181,6 +220,33 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           metadata?: any;
           name?: string;
           stripeCustomerId: string;
+          userId?: string;
+        } | null,
+        Name
+      >;
+      getCustomerByEmail: FunctionReference<
+        "query",
+        "internal",
+        { email: string },
+        {
+          email?: string;
+          metadata?: any;
+          name?: string;
+          stripeCustomerId: string;
+          userId?: string;
+        } | null,
+        Name
+      >;
+      getCustomerByUserId: FunctionReference<
+        "query",
+        "internal",
+        { userId: string },
+        {
+          email?: string;
+          metadata?: any;
+          name?: string;
+          stripeCustomerId: string;
+          userId?: string;
         } | null,
         Name
       >;
@@ -237,6 +303,19 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           stripeSubscriptionId: string;
           userId?: string;
         } | null,
+        Name
+      >;
+      listCheckoutSessions: FunctionReference<
+        "query",
+        "internal",
+        { stripeCustomerId: string },
+        Array<{
+          metadata?: any;
+          mode: string;
+          status: string;
+          stripeCheckoutSessionId: string;
+          stripeCustomerId?: string;
+        }>,
         Name
       >;
       listInvoices: FunctionReference<
@@ -360,6 +439,25 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         }>,
         Name
       >;
+      listSubscriptionsByOrgId: FunctionReference<
+        "query",
+        "internal",
+        { orgId: string },
+        Array<{
+          cancelAt?: number;
+          cancelAtPeriodEnd: boolean;
+          currentPeriodEnd: number;
+          metadata?: any;
+          orgId?: string;
+          priceId: string;
+          quantity?: number;
+          status: string;
+          stripeCustomerId: string;
+          stripeSubscriptionId: string;
+          userId?: string;
+        }>,
+        Name
+      >;
       listSubscriptionsByUserId: FunctionReference<
         "query",
         "internal",
@@ -394,7 +492,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       updateSubscriptionQuantity: FunctionReference<
         "action",
         "internal",
-        { apiKey: string; quantity: number; stripeSubscriptionId: string },
+        { quantity: number; stripeSubscriptionId: string },
         null,
         Name
       >;

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -107,11 +107,6 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
 
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
-
 /**
  * A set of services for use within Convex query functions.
  *

--- a/src/component/private.ts
+++ b/src/component/private.ts
@@ -352,6 +352,20 @@ export const handleCheckoutSessionCompleted = mutation({
   },
 });
 
+const INVOICE_STATUS_ORDER: Record<string, number> = {
+  draft: 0,
+  open: 1,
+  paid: 2,
+  uncollectible: 2,
+  void: 2,
+};
+
+function latestInvoiceStatus(existingStatus: string, incomingStatus: string) {
+  const existingOrder = INVOICE_STATUS_ORDER[existingStatus] ?? 0;
+  const incomingOrder = INVOICE_STATUS_ORDER[incomingStatus] ?? 0;
+  return incomingOrder >= existingOrder ? incomingStatus : existingStatus;
+}
+
 export const handleInvoiceCreated = mutation({
   args: {
     stripeInvoiceId: v.string(),
@@ -396,7 +410,7 @@ export const handleInvoiceCreated = mutation({
         ...(args.stripeSubscriptionId !== undefined && {
           stripeSubscriptionId: args.stripeSubscriptionId,
         }),
-        status: args.status,
+        status: latestInvoiceStatus(existing.status, args.status),
         amountDue: args.amountDue,
         amountPaid: args.amountPaid,
         created: args.created,

--- a/src/component/private.ts
+++ b/src/component/private.ts
@@ -119,6 +119,31 @@ export const handleCustomerUpdated = mutation({
   },
 });
 
+export const handleCustomerDeleted = mutation({
+  args: {
+    stripeCustomerId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const customer = await ctx.db
+      .query("customers")
+      .withIndex("by_stripe_customer_id", (q) =>
+        q.eq("stripeCustomerId", args.stripeCustomerId),
+      )
+      .unique();
+
+    if (customer) {
+      await ctx.db.patch(customer._id, {
+        email: undefined,
+        name: undefined,
+        metadata: {},
+      });
+    }
+
+    return null;
+  },
+});
+
 function deriveCancelAtPeriodEnd(
   cancelAt: number | undefined,
   currentPeriodEnd: number,
@@ -202,6 +227,7 @@ export const handleSubscriptionCreated = mutation({
 export const handleSubscriptionUpdated = mutation({
   args: {
     stripeSubscriptionId: v.string(),
+    stripeCustomerId: v.optional(v.string()),
     status: v.string(),
     currentPeriodEnd: v.number(),
     cancelAtPeriodEnd: v.boolean(),
@@ -219,15 +245,13 @@ export const handleSubscriptionUpdated = mutation({
       )
       .unique();
 
+    const metadata = args.metadata || {};
+    const orgId = metadata.orgId as string | undefined;
+    const userId = metadata.userId as string | undefined;
+    const cancelAtPeriodEnd = args.cancelAtPeriodEnd || 
+      deriveCancelAtPeriodEnd(args.cancelAt, args.currentPeriodEnd);
+
     if (subscription) {
-      // Extract orgId and userId from metadata if present
-      const metadata = args.metadata || {};
-      const orgId = metadata.orgId as string | undefined;
-      const userId = metadata.userId as string | undefined;
-
-      const cancelAtPeriodEnd = args.cancelAtPeriodEnd || 
-        deriveCancelAtPeriodEnd(args.cancelAt, args.currentPeriodEnd);
-
       await ctx.db.patch(subscription._id, {
         status: args.status,
         currentPeriodEnd: args.currentPeriodEnd,
@@ -239,6 +263,20 @@ export const handleSubscriptionUpdated = mutation({
         ...(args.metadata !== undefined && { metadata }),
         ...(orgId !== undefined && { orgId }),
         ...(userId !== undefined && { userId }),
+      });
+    } else if (args.stripeCustomerId && args.priceId) {
+      await ctx.db.insert("subscriptions", {
+        stripeSubscriptionId: args.stripeSubscriptionId,
+        stripeCustomerId: args.stripeCustomerId,
+        status: args.status,
+        currentPeriodEnd: args.currentPeriodEnd,
+        cancelAtPeriodEnd,
+        cancelAt: args.cancelAt ?? undefined,
+        quantity: args.quantity,
+        priceId: args.priceId,
+        metadata,
+        orgId,
+        userId,
       });
     }
 
@@ -323,6 +361,7 @@ export const handleInvoiceCreated = mutation({
     amountDue: v.number(),
     amountPaid: v.number(),
     created: v.number(),
+    metadata: v.optional(v.any()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -333,25 +372,38 @@ export const handleInvoiceCreated = mutation({
       )
       .unique();
 
-    if (!existing) {
-      // Look up orgId/userId from the subscription if available
-      let orgId: string | undefined;
-      let userId: string | undefined;
+    const metadata = args.metadata || {};
+    let orgId = metadata.orgId as string | undefined;
+    let userId = metadata.userId as string | undefined;
 
-      if (args.stripeSubscriptionId) {
-        const subscription = await ctx.db
-          .query("subscriptions")
-          .withIndex("by_stripe_subscription_id", (q) =>
-            q.eq("stripeSubscriptionId", args.stripeSubscriptionId!),
-          )
-          .unique();
+    if ((!orgId || !userId) && args.stripeSubscriptionId) {
+      const subscription = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_stripe_subscription_id", (q) =>
+          q.eq("stripeSubscriptionId", args.stripeSubscriptionId!),
+        )
+        .unique();
 
-        if (subscription) {
-          orgId = subscription.orgId;
-          userId = subscription.userId;
-        }
+      if (subscription) {
+        orgId = orgId ?? subscription.orgId;
+        userId = userId ?? subscription.userId;
       }
+    }
 
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        stripeCustomerId: args.stripeCustomerId,
+        ...(args.stripeSubscriptionId !== undefined && {
+          stripeSubscriptionId: args.stripeSubscriptionId,
+        }),
+        status: args.status,
+        amountDue: args.amountDue,
+        amountPaid: args.amountPaid,
+        created: args.created,
+        ...(orgId !== undefined && { orgId }),
+        ...(userId !== undefined && { userId }),
+      });
+    } else {
       await ctx.db.insert("invoices", {
         stripeInvoiceId: args.stripeInvoiceId,
         stripeCustomerId: args.stripeCustomerId,

--- a/src/component/public.test.ts
+++ b/src/component/public.test.ts
@@ -430,6 +430,35 @@ test("invoice creation updates existing invoices and uses invoice metadata", asy
   });
 });
 
+test("delayed invoice.created does not downgrade finalized invoice status", async () => {
+  const t = convexTest(schema, modules);
+
+  await t.mutation(api.private.handleInvoiceCreated, {
+    stripeInvoiceId: "in_out_of_order",
+    stripeCustomerId: "cus_out_of_order",
+    status: "open",
+    amountDue: 1500,
+    amountPaid: 0,
+    created: 1_700_000_000,
+  });
+
+  await t.mutation(api.private.handleInvoiceCreated, {
+    stripeInvoiceId: "in_out_of_order",
+    stripeCustomerId: "cus_out_of_order",
+    status: "draft",
+    amountDue: 1500,
+    amountPaid: 0,
+    created: 1_700_000_000,
+  });
+
+  const invoices = await t.query(api.public.listInvoices, {
+    stripeCustomerId: "cus_out_of_order",
+  });
+
+  expect(invoices).toHaveLength(1);
+  expect(invoices[0].status).toBe("open");
+});
+
 test("customer deletion scrubs PII but preserves linkage", async () => {
   const t = convexTest(schema, modules);
 

--- a/src/component/public.test.ts
+++ b/src/component/public.test.ts
@@ -1,6 +1,6 @@
 import { convexTest } from "convex-test";
 import { expect, test } from "vitest";
-import { api, internal } from "./_generated/api.js";
+import { api } from "./_generated/api.js";
 import schema from "./schema.js";
 import { modules } from "./setup.test.js";
 
@@ -361,6 +361,100 @@ test("payment with orgId and userId extraction from metadata", async () => {
     userId: "user_demo_456",
     customField: "custom_value",
   });
+});
+
+test("subscription update upserts when created webhook is missing", async () => {
+  const t = convexTest(schema, modules);
+
+  await t.mutation(api.private.handleSubscriptionUpdated as any, {
+    stripeSubscriptionId: "sub_update_first",
+    stripeCustomerId: "cus_update_first",
+    status: "active",
+    currentPeriodEnd: 1_800_000_000,
+    cancelAtPeriodEnd: false,
+    quantity: 4,
+    priceId: "price_update_first",
+    metadata: { userId: "user_update_first", orgId: "org_update_first" },
+  });
+
+  const subscription = await t.query(api.public.getSubscription, {
+    stripeSubscriptionId: "sub_update_first",
+  });
+
+  expect(subscription).toMatchObject({
+    stripeSubscriptionId: "sub_update_first",
+    stripeCustomerId: "cus_update_first",
+    status: "active",
+    currentPeriodEnd: 1_800_000_000,
+    quantity: 4,
+    priceId: "price_update_first",
+    userId: "user_update_first",
+    orgId: "org_update_first",
+  });
+});
+
+test("invoice creation updates existing invoices and uses invoice metadata", async () => {
+  const t = convexTest(schema, modules);
+
+  await t.mutation(api.private.handleInvoiceCreated, {
+    stripeInvoiceId: "in_upsert",
+    stripeCustomerId: "cus_invoice_upsert",
+    status: "draft",
+    amountDue: 1000,
+    amountPaid: 0,
+    created: 1_700_000_000,
+  });
+
+  await t.mutation(api.private.handleInvoiceCreated as any, {
+    stripeInvoiceId: "in_upsert",
+    stripeCustomerId: "cus_invoice_upsert",
+    status: "open",
+    amountDue: 1500,
+    amountPaid: 500,
+    created: 1_700_000_000,
+    metadata: { userId: "user_invoice_meta", orgId: "org_invoice_meta" },
+  });
+
+  const invoices = await t.query(api.public.listInvoicesByOrgId, {
+    orgId: "org_invoice_meta",
+  });
+
+  expect(invoices).toHaveLength(1);
+  expect(invoices[0]).toMatchObject({
+    stripeInvoiceId: "in_upsert",
+    status: "open",
+    amountDue: 1500,
+    amountPaid: 500,
+    userId: "user_invoice_meta",
+    orgId: "org_invoice_meta",
+  });
+});
+
+test("customer deletion scrubs PII but preserves linkage", async () => {
+  const t = convexTest(schema, modules);
+
+  await t.mutation(api.private.handleCustomerCreated, {
+    stripeCustomerId: "cus_delete",
+    email: "delete@example.com",
+    name: "Delete Me",
+    metadata: { userId: "user_delete", tier: "pro" },
+  });
+
+  await t.mutation((api.private as any).handleCustomerDeleted, {
+    stripeCustomerId: "cus_delete",
+  });
+
+  const customer = await t.query(api.public.getCustomer, {
+    stripeCustomerId: "cus_delete",
+  });
+
+  expect(customer).toMatchObject({
+    stripeCustomerId: "cus_delete",
+    userId: "user_delete",
+    metadata: {},
+  });
+  expect(customer?.email).toBeUndefined();
+  expect(customer?.name).toBeUndefined();
 });
 
 test("list payments by customer ID", async () => {


### PR DESCRIPTION
## Summary
- Upgrade Stripe SDK to v22 with configurable API version support and refreshed dependency/audit cleanup.
- Add Checkout params passthrough with tests/docs, including non-hosted UI mode handling.
- Improve webhook robustness for customer deletion PII scrubbing, subscription update upserts, invoice upserts, and Stripe v22 invoice parent metadata.
- Document issue/PR triage, dependency follow-ups, and the products/prices feature design wave.

## Test plan
- [x] npm test
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] npm audit --omit=optional --audit-level=moderate


Made with [Cursor](https://cursor.com)